### PR TITLE
Upgrade weston to 1.7.0

### DIFF
--- a/l4t-nouveau.xml
+++ b/l4t-nouveau.xml
@@ -23,5 +23,5 @@
   <project path="wayland" name="wayland/wayland.git" remote="freedesktop" revision="refs/tags/1.7.0"/>
   <project path="mesa" name="mesa.git" remote="gnurou" revision="gk20a"/>
   <project path="kmscube" name="kmscube.git" remote="gnurou" revision="gk20a"/>
-  <project path="weston" name="weston.git" remote="gnurou" revision="baserock/james/weston"/>
+  <project path="weston" name="delta/weston.git" remote="baserock" revision="baserock/weston-1.7.0/tegra"/>
 </manifest>


### PR DESCRIPTION
Hello,

This commit upgrades weston to 1.7.0, also changes the remote back to git.baserock.org