### PR TITLE
Archlinux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ If you prefer to sync to the internal eMMC, do the following:
 6. unmount the eMMC partition. This might take a while as cached data is flushed to the device.
 7. press ctrl+c in the U-boot console and switch the board off.
 
-Then turn your board on (after inserting the SD card if you synced to it!). U-boot should start the kernel we just cross-compiled. The Nouveau modules will then be loaded in turn, and you should be presented with a login prompt (login with user `ubuntu` and password `ubuntu`).
+Then turn your board on (after inserting the SD card if you synced to it!). U-boot should start the kernel we just cross-compiled. The Nouveau modules will then be loaded in turn, and you should be presented with a login prompt.
+On the L4T target, login with user `ubuntu` and password `ubuntu`. On ArchLinuxARM, use `root` for both the login and password.
 
 Errors During Boot
 ------------------

--- a/README.md
+++ b/README.md
@@ -19,12 +19,18 @@ You will need a bunch of tools to download and cross-compile the various project
 - repo
 - git
 - autotools
+- uboot-tools
 - basic 32-bit libraries
 - Wayland (for the wayland-scanner program)
 
 Under Ubuntu 14.04, the following command will get you all set:
 
     $ sudo apt-get install git build-essential wget phablet-tools autoconf automake libtool libc6-i386 lib32stdc++6 lib32z1 pkg-config libwayland-dev bison flex bc u-boot-tools glib-2.0 realpath libffi-dev
+
+Under Archlinux (2015-10-09), run the following commands:
+
+    $ yaourt -S aur/repo # Or install the package by downloading it from AUR yourself
+    $ sudo pacman -Sy base-devel wget git crypto++ libffi uboot-tools wayland
 
 U-Boot
 ------


### PR DESCRIPTION
Hey Alexandre and Lauri,

Thanks a lot for all those scripts and the instructions. I managed to get my board running but I had the following issues:
- I did not have the uboot-tools package installed (would be nice to add it to the list of requirements)
- the default password when using archlinuxarm is root:root

Since I did not have the mkimage binary (provided by uboot-tools), the build-kernel script failed and I completely missed the error. I had no clue about uboot so I did not know about boot.scr and I was wondering why uboot would not pick up my kernel... Noob here!

Anyway, here are two patches that would make it easier for the archers like me to follow the instructions.

Now I am off to actually try the nouveau support! Cheers!